### PR TITLE
Changed default connection string

### DIFF
--- a/src/Chirp.Web/appsettings.json
+++ b/src/Chirp.Web/appsettings.json
@@ -6,7 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=..\\Chirp.Infrastructure\\Data\\Cheep.db",
+    "DefaultConnection": "Data Source=../Chirp.Infrastructure/Data/Cheep.db",
     "CheepDBContextConnection": "Data Source=Chirp.Web.db"
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
# Updated default connection string
Problem description covered in [this](https://github.com/ITU-BDSA2024-GROUP7/Chirp/issues/99) issue.
Updated default connection string to use Unix-style path separators for cross-platform compatibility. Before the string was using double backslashes (..\\) which is Windows-specific.