### PR TITLE
Enhance addtry catch for GitHub secrets

### DIFF
--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -31,9 +31,17 @@ namespace Chirp.Web
             string? clientId = builder.Configuration["AUTHENTICATION_GITHUB_CLIENTID"];
             string? clientSecret = builder.Configuration["AUTHENTICATION_GITHUB_CLIENTSECRET"];
 
-            if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret))
+            if (string.IsNullOrEmpty(clientId) && string.IsNullOrEmpty(clientSecret))
             {
-                throw new ApplicationException("GitHub ClientId and ClientSecret must be provided. Ensure that the secrets are set in the configuration.");
+                throw new ApplicationException("Failed to retrieve both the Github Client ID and Secret. Make sure that the values are set on the machine.");
+            }
+            if (string.IsNullOrEmpty(clientId))
+            {
+                throw new ApplicationException("Failed to retrieve the Github Client ID. Make sure that the github value is set on the machine.");
+            }
+            if (string.IsNullOrEmpty(clientSecret))
+            {
+                throw new ApplicationException("Failed to retrieve the Github Secret. Make sure that the github value is set on the machine.");
             }
             
             // Add GitHub Services

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -31,9 +31,17 @@ namespace Chirp.Web
             builder.Services.AddAuthentication()
                 .AddGitHub(options =>
                 {
-                    options.ClientId = builder.Configuration["AUTHENTICATION_GITHUB_CLIENTID"]!;
-                    options.ClientSecret = builder.Configuration["AUTHENTICATION_GITHUB_CLIENTSECRET"]!;
-                    options.CallbackPath = new PathString("/signin-github");
+                    try
+                    {
+                        options.ClientId = builder.Configuration["AUTHENTICATION_GITHUB_CLIENTID"]!;
+                        options.ClientSecret = builder.Configuration["AUTHENTICATION_GITHUB_CLIENTSECRET"]!;
+                        options.CallbackPath = new PathString("/signin-github");
+                    }
+                    catch (Exception e)
+                    {
+                        throw new ApplicationException("Failed to retrieve the Github client ID and Secret. Make sure that the github secrets is set on the machine.", e);
+                    }
+                    
                 });
             
             builder.Services.AddSession();

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -27,21 +27,22 @@ namespace Chirp.Web
                     options.SignIn.RequireConfirmedAccount = true)
                 .AddEntityFrameworkStores<CheepDBContext>();
 
+            // Retrieve ClientId and ClientSecret from configuration
+            string? clientId = builder.Configuration["AUTHENTICATION_GITHUB_CLIENTID"];
+            string? clientSecret = builder.Configuration["AUTHENTICATION_GITHUB_CLIENTSECRET"];
+
+            if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret))
+            {
+                throw new ApplicationException("GitHub ClientId and ClientSecret must be provided. Ensure that the secrets are set in the configuration.");
+            }
+            
             // Add GitHub Services
             builder.Services.AddAuthentication()
                 .AddGitHub(options =>
                 {
-                    try
-                    {
-                        options.ClientId = builder.Configuration["AUTHENTICATION_GITHUB_CLIENTID"]!;
-                        options.ClientSecret = builder.Configuration["AUTHENTICATION_GITHUB_CLIENTSECRET"]!;
-                        options.CallbackPath = new PathString("/signin-github");
-                    }
-                    catch (Exception e)
-                    {
-                        throw new ApplicationException("Failed to retrieve the Github client ID and Secret. Make sure that the github secrets is set on the machine.", e);
-                    }
-                    
+                    options.ClientId = clientId;
+                    options.ClientSecret = clientSecret;
+                    options.CallbackPath = new PathString("/signin-github");
                 });
             
             builder.Services.AddSession();


### PR DESCRIPTION
# Error handling for github secret values
If a developer hasn't set the github client id or github secret for their local machine it doesnt build the program properly nor give any usefull exceptions.
Now in the pipeline when setting the client id and secret, the programs check if they are null or empty. If so the program throws an exception.