### PR TITLE
6 IDE warnings absolved

### DIFF
--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -53,7 +53,7 @@ namespace Chirp.Infrastructure.Repositories
             return await query.ToListAsync();
         }
         // get total count of pages 
-        public async Task<int> GetTotalPages(string authorName = null)
+        public async Task<int> GetTotalPages(string authorName = "")
         {
             var query = _dbContext.Cheeps.AsQueryable();
             
@@ -80,15 +80,19 @@ namespace Chirp.Infrastructure.Repositories
             }
 
             // Create a new Cheep 
-            Cheep newCheep = new Cheep
+            if (author != null)
             {
-                Text = cheepDTO.Text,
-                Author =  author,
-                TimeStamp = DateTimeOffset.UtcNow.UtcDateTime // Use current timestamp in UNIX format
-            };
+                Cheep newCheep = new Cheep
+                {
+                    Text = cheepDTO.Text,
+                    Author =  author,
+                    TimeStamp = DateTimeOffset.UtcNow.UtcDateTime // Use current timestamp in UNIX format
+                };
 
-            // Add the new Cheep to the DbContext
-            await _dbContext.Cheeps.AddAsync(newCheep);
+                // Add the new Cheep to the DbContext
+                await _dbContext.Cheeps.AddAsync(newCheep);
+            }
+
             await _dbContext.SaveChangesAsync(); // Persist the changes to the database
         }
 

--- a/src/Chirp.Infrastructure/Services/CheepService.cs
+++ b/src/Chirp.Infrastructure/Services/CheepService.cs
@@ -16,7 +16,7 @@ public class CheepService : ICheepService
         _cheepRepository = cheepRepository;
     }
     
-    public async Task<int> GetTotalPageNumber(string authorName = null)
+    public async Task<int> GetTotalPageNumber(string authorName = "")
     {
         return await _cheepRepository.GetTotalPages(authorName);
     }

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -23,7 +23,7 @@ public class PublicModel : PageModel
     /// <returns></returns>
     public async Task<IActionResult> OnGet([FromQuery] int page)
     {
-        if (!(page is int) || page <= 0)
+        if (page <= 0)
         {
             page = 1;
         }

--- a/src/Chirp.Web/Pages/Shared/_Navbar.cshtml
+++ b/src/Chirp.Web/Pages/Shared/_Navbar.cshtml
@@ -1,5 +1,5 @@
 ﻿<div class=navigation>
-    @if (User.Identity.IsAuthenticated)
+    @if (User.Identity != null && User.Identity.IsAuthenticated)
     {
         <div>
             <a href="/@(User.Identity.Name)">My timeline</a> |

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -20,7 +20,7 @@ public class UserTimelineModel : PageModel
     // Runs when site is loaded (Request Method:GET)
     public async Task<IActionResult> OnGet(string author, [FromQuery] int page)
     {
-        if (!(page is int) || page <= 0)
+        if (page <= 0)
         {
             page = 1;
         }


### PR DESCRIPTION
- Various methods used ``string xyz = null`` which gave a warning as it is a non nullable reference type, used ``string xyz = ""`` instead. 
- !(page is int) was removed from public- and usertimeline.cs, as we already ensure that the value is an int in the cshtml.