### PR TITLE
Add Secrets Reference for Integration Tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,4 +27,7 @@ jobs:
       run: dotnet build src/Chirp.Web/Chirp.Web.csproj --no-restore
 
     - name: Test
+      env:
+        AUTHENTICATION_GITHUB_CLIENTID: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTID }}
+        AUTHENTICATION_GITHUB_CLIENTSECRET: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTSECRET }}
       run: dotnet test test/Chirp.Test/Chirp.Test.csproj --verbosity normal


### PR DESCRIPTION
# Context
For the past week, our integration tests have been unable to access the GitHub Client ID and Secret, causing test failures and preventing successful test execution.

# Solution
This update adds CLIENTID and CLIENTSECRET as environment variables in the build and test workflow. With these additions, the builder pipeline now successfully recognizes the required variables, ensuring integration tests can run as expected.