### PR TITLE
Enforce HSTS Header

### DIFF
--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -15,7 +15,10 @@ namespace Chirp.Web
 
             // Add services to the container
             builder.Services.AddRazorPages();
-
+            
+            // Once you are sure everything works, you might want to increase this value to up to 1 or 2 years
+            builder.Services.AddHsts(options => options.MaxAge = TimeSpan.FromDays(700));
+            
             // Load database connection via configuration
             string? connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
 


### PR DESCRIPTION
To permanently convince the browser to use HTTPS, we will send a "HTTP Strict Transport Security (HSTS)" header.

@niko391a