### PR TITLE
Saves release as a draft

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -139,5 +139,6 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: "Chirp*.zip"
+          draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Create release as a draft
### What
This line of code changes the release to start as a draft instead of a live release. 

### Why
Making the release start as a draft allows us to write a description with new features / bug fixes before it goes live.

### How
When `draft` isn't specified in the workflow, the default value is `false`. By adding `draft: true` it sets the value to true, making the release start as a draft.