### PR TITLE
Feature Deleting Cheeps

### DIFF
--- a/src/Chirp.Core/Interfaces/ICheepRepository.cs
+++ b/src/Chirp.Core/Interfaces/ICheepRepository.cs
@@ -9,4 +9,6 @@ public interface ICheepRepository
     Task CreateCheep(CheepDTO newCheep);
     Task UpdateCheep(CheepDTO alteredCheep);
     Task<int> GetTotalPages(string authorName);
+    Task DeleteCheep(int cheepId);
+    Task DeleteCheepByAuthor(AuthorDTO author);
 }

--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -152,7 +152,16 @@ namespace Chirp.Infrastructure.Repositories
             if (cheeps != null)
             {
                 _dbContext.Cheeps.RemoveRange(cheeps);
-                _dbContext.Authors.Remove(await _dbContext.Authors.FindAsync(Author.Name));
+
+                // Retrieve the author by name and then remove them
+                var author = await _dbContext.Authors
+                    .FirstOrDefaultAsync(a => a.Name == Author.Name);
+
+                if (author != null)
+                {
+                    _dbContext.Authors.Remove(author);
+                }
+
                 await _dbContext.SaveChangesAsync();
             }
         }

--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -134,6 +134,29 @@ namespace Chirp.Infrastructure.Repositories
             await _dbContext.SaveChangesAsync(); // Persist the changes to the database
         }
         
+        public async Task DeleteCheep(int cheepId)
+        {
+            var cheep = await _dbContext.Cheeps.FindAsync(cheepId);
+            if (cheep != null)
+            {
+                _dbContext.Cheeps.Remove(cheep);
+                await _dbContext.SaveChangesAsync();
+            }
+        }
+        
+        public async Task DeleteCheepByAuthor(AuthorDTO Author)
+        {
+            var cheeps = await _dbContext.Cheeps
+                .Where(cheep => cheep.Author.Name == Author.Name)
+                .ToListAsync();
+            if (cheeps != null)
+            {
+                _dbContext.Cheeps.RemoveRange(cheeps);
+                _dbContext.Authors.Remove(await _dbContext.Authors.FindAsync(Author.Name));
+                await _dbContext.SaveChangesAsync();
+            }
+        }
+        
         public async Task<List<CheepDTO>> RetrieveAllCheepsForEndPoint()
         {
             var query = _dbContext.Cheeps

--- a/src/Chirp.Infrastructure/Services/CheepService.cs
+++ b/src/Chirp.Infrastructure/Services/CheepService.cs
@@ -12,6 +12,8 @@ public interface ICheepService
     public Task<List<Core.DTOs.CheepDTO>> RetrieveAllCheeps();
     
     public Task CreateCheep(CheepDTO Cheep);
+    
+    public Task DeleteCheepByAuthor(AuthorDTO Author);
 }
 public class CheepService : ICheepService
 {
@@ -43,5 +45,9 @@ public class CheepService : ICheepService
     public async Task CreateCheep(CheepDTO Cheep)
     {
         await _cheepRepository.CreateCheep(Cheep);
+    }
+    public async Task DeleteCheepByAuthor(AuthorDTO Author)
+    {
+        await _cheepRepository.DeleteCheepByAuthor(Author);
     }
 }

--- a/src/Chirp.Infrastructure/Services/CheepService.cs
+++ b/src/Chirp.Infrastructure/Services/CheepService.cs
@@ -50,4 +50,8 @@ public class CheepService : ICheepService
     {
         await _cheepRepository.DeleteCheepByAuthor(Author);
     }
+    public async Task DeleteCheep(int cheepId)
+    {
+        await _cheepRepository.DeleteCheep(cheepId);
+    }
 }

--- a/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml
@@ -1,0 +1,34 @@
+﻿@page
+@using Chirp.Web.Areas.Identity.Pages.Account.Manage
+@model DeletePersonalDataModel
+@{
+    ViewData["Title"] = "Delete Personal Data";
+    ViewData["ActivePage"] = ManageNavPages.PersonalData;
+}
+
+<h3>@ViewData["Title"]</h3>
+
+<div class="alert alert-warning" role="alert">
+    <p>
+        <strong>Deleting this data will permanently remove your account, and this cannot be recovered.</strong>
+    </p>
+</div>
+
+<div>
+    <form id="delete-user" method="post">
+        <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+        @if (Model.RequirePassword)
+        {
+            <div class="form-floating mb-3">
+                <input asp-for="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" placeholder="Please enter your password." />
+                <label asp-for="Input.Password" class="form-label"></label>
+                <span asp-validation-for="Input.Password" class="text-danger"></span>
+            </div>
+        }
+        <button class="w-100 btn btn-lg btn-danger" type="submit">Delete data and close my account</button>
+    </form>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml.cs
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+#nullable disable
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Chirp.Core.DTOs;
+using Chirp.Infrastructure.Data;
+using Chirp.Infrastructure.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+
+namespace Chirp.Web.Areas.Identity.Pages.Account.Manage
+{
+    public class DeletePersonalDataModel : PageModel
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly SignInManager<ApplicationUser> _signInManager;
+        private readonly ILogger<DeletePersonalDataModel> _logger;
+        private readonly CheepService _service;
+        
+
+        public DeletePersonalDataModel(
+            UserManager<ApplicationUser> userManager,
+            SignInManager<ApplicationUser> signInManager,
+            ILogger<DeletePersonalDataModel> logger,
+            CheepService service)
+        {
+            _userManager = userManager;
+            _signInManager = signInManager;
+            _logger = logger;
+            _service = service;
+        }
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        [BindProperty]
+        public InputModel Input { get; set; }
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public class InputModel
+        {
+            /// <summary>
+            ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            [Required]
+            [DataType(DataType.Password)]
+            public string Password { get; set; }
+        }
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public bool RequirePassword { get; set; }
+
+        public async Task<IActionResult> OnGet()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+            {
+                return NotFound($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
+            }
+
+            RequirePassword = await _userManager.HasPasswordAsync(user);
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+            {
+                return NotFound($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
+            }
+
+            RequirePassword = await _userManager.HasPasswordAsync(user);
+            if (RequirePassword)
+            {
+                if (!await _userManager.CheckPasswordAsync(user, Input.Password))
+                {
+                    ModelState.AddModelError(string.Empty, "Incorrect password.");
+                    return Page();
+                }
+            }
+            if (User.Identity != null && User.Identity.IsAuthenticated)
+            {
+                var authorName = User.Identity.Name;
+                var authorEmail = User.Identity.Name;
+
+                var Author = new AuthorDTO
+                {
+                    Name = authorName,
+                    Email = authorEmail
+                };
+                await _service.DeleteCheepByAuthor(Author);
+            }
+
+
+            var result = await _userManager.DeleteAsync(user);
+            var userId = await _userManager.GetUserIdAsync(user);
+            if (!result.Succeeded)
+            {
+                throw new InvalidOperationException($"Unexpected error occurred deleting user.");
+            }
+
+            await _signInManager.SignOutAsync();
+
+            _logger.LogInformation("User with ID '{UserId}' deleted themselves.", userId);
+
+            return Redirect("~/");
+        }
+    }
+}

--- a/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/ManageNavPages.cs
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/ManageNavPages.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+#nullable disable
+
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace  Chirp.Web.Areas.Identity.Pages.Account.Manage
+{
+    /// <summary>
+    ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class ManageNavPages
+    {
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string Index => "Index";
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string Email => "Email";
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string ChangePassword => "ChangePassword";
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string DownloadPersonalData => "DownloadPersonalData";
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string DeletePersonalData => "DeletePersonalData";
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string ExternalLogins => "ExternalLogins";
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string PersonalData => "PersonalData";
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string TwoFactorAuthentication => "TwoFactorAuthentication";
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string IndexNavClass(ViewContext viewContext) => PageNavClass(viewContext, Index);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string EmailNavClass(ViewContext viewContext) => PageNavClass(viewContext, Email);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string ChangePasswordNavClass(ViewContext viewContext) => PageNavClass(viewContext, ChangePassword);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string DownloadPersonalDataNavClass(ViewContext viewContext) => PageNavClass(viewContext, DownloadPersonalData);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string DeletePersonalDataNavClass(ViewContext viewContext) => PageNavClass(viewContext, DeletePersonalData);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string ExternalLoginsNavClass(ViewContext viewContext) => PageNavClass(viewContext, ExternalLogins);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string PersonalDataNavClass(ViewContext viewContext) => PageNavClass(viewContext, PersonalData);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string TwoFactorAuthenticationNavClass(ViewContext viewContext) => PageNavClass(viewContext, TwoFactorAuthentication);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string PageNavClass(ViewContext viewContext, string page)
+        {
+            var activePage = viewContext.ViewData["ActivePage"] as string
+                ?? System.IO.Path.GetFileNameWithoutExtension(viewContext.ActionDescriptor.DisplayName);
+            return string.Equals(activePage, page, StringComparison.OrdinalIgnoreCase) ? "active" : null;
+        }
+    }
+}

--- a/test/Chirp.TestE2E/E2ETests.cs
+++ b/test/Chirp.TestE2E/E2ETests.cs
@@ -695,6 +695,94 @@ public class E2ETests : PageTest
         // Clean up
         await DeleteUser();   
     }
+    [Test]
+    [Category("End2End")]
+    public async Task CheepingCheeps()
+    {
+        await RegisterUser();
+        await LoginUser();
+        
+        await _page.Locator("#CheepText").ClickAsync();
+        await _page.Locator("#CheepText").FillAsync("Hello World!");
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
+        await Expect(_page.Locator("li").Filter(new() { HasText = "Hello World!" }).First).ToBeVisibleAsync();
+
+        
+        // Clean up and delete data
+        await DeleteUser();   
+    }
+
+    [Test]
+    [Category("End2End")]
+    public async Task CheepingFromPrivateTimeline()
+    {
+        {
+            await RegisterUser();
+            await LoginUser();
+            
+            await _page.GetByRole(AriaRole.Link, new() { Name = "My timeline" }).ClickAsync();
+            await _page.Locator("#CheepText").ClickAsync();
+            await _page.Locator("#CheepText").FillAsync("Hello World!");
+            await _page.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
+            await Expect(_page.Locator("li").Filter(new() { HasText = "Hello World!" }).First).ToBeVisibleAsync();
+
+        
+            // Clean up and delete data
+            await DeleteUser();   
+        }
+    }
+    [Test]
+    [Category("End2End")]
+    public async Task EmptyCheeps()
+    {
+        {
+            await RegisterUser();
+            await LoginUser();
+            
+            await _page.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
+            await Expect(_page.GetByText("At least write something")).ToBeVisibleAsync();
+        
+            // Clean up and delete data
+            await DeleteUser();   
+        }
+    }
+    [Test]
+    [Category("End2End")]
+    public async Task LongCheeps()
+    {
+        {
+            await RegisterUser();
+            await LoginUser();
+            
+            await _page.Locator("#CheepText").ClickAsync();
+            await _page.Locator("#CheepText").FillAsync("Very Long Message Very Long Message Very Long Message Very Long Message Very Long Message Very Long Message Very Long Message Very Long Message Very Long Message Very Long Message Very Long Message Very Long Message Very Long Message Very Long Message Very Long Message Very Long Message Very Long Message Very Long Message ");
+            await _page.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
+            await Expect(_page.GetByText("Maximum length is 160")).ToBeVisibleAsync();
+        
+            // Clean up and delete data
+            await DeleteUser();   
+        }
+    }
+    [Test]
+    [Category("End2End")]
+    public async Task DeletedCheeps()
+    {
+        {
+            await RegisterUser();
+            await LoginUser();
+            
+            await _page.Locator("#CheepText").ClickAsync();
+            await _page.Locator("#CheepText").FillAsync("Hello World!");
+            await _page.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
+            // Clean up and delete data
+            await DeleteUser();   
+            
+            // check that the cheep is deleted
+            await _page.GetByRole(AriaRole.Link, new() { Name = "public timeline" }).ClickAsync();
+            await Expect(_page.GetByText("Public Timeline Jacqualine")).ToBeVisibleAsync();
+            
+        }
+    }
 }
 
 // This is used to get the GitHub credentials from the user secrets

--- a/test/Chirp.TestUnit/UnitTests.cs
+++ b/test/Chirp.TestUnit/UnitTests.cs
@@ -1,3 +1,5 @@
+using Chirp.Core.DTOs;
+
 namespace Chirp.Test;
 
 public class UnitTests
@@ -112,12 +114,118 @@ public class UnitTests
          // Assert
          Assert.True(cheepList.Count() == 4);
      }
-    
-    
-    
-    
-    
-    private static String UnixTimeStampToDateTimeString(double unixTimeStamp)
+
+     [Fact]
+     public async void DeleteCheepsByAuthor()
+     {
+         // Arrange
+         using var connection = new SqliteConnection("Filename=:memory:");
+         await connection.OpenAsync();                              
+         var builder = new DbContextOptionsBuilder<CheepDBContext>().UseSqlite(connection);
+                                                           
+         using var context = new CheepDBContext(builder.Options);   
+         await context.Database.EnsureCreatedAsync();               
+        
+         // Seed the database with a test entry
+         var author1 = new Author() { AuthorId = 1, Cheeps = null, Email = "helge@hotmail", Name = "Helge" };
+         var author2 = new Author() { AuthorId = 2, Cheeps = null, Email = "", Name = "Adrian" };
+         
+         var cheep1 = new Cheep
+         {
+             CheepId = 1,
+             Author = author1,
+             AuthorId = author1.AuthorId,
+             Text = "Sådan!",
+             TimeStamp = DateTimeOffset.FromUnixTimeSeconds(1690892208).UtcDateTime // Ensure this matches the format in your model
+         };
+         var cheep2 = new Cheep
+         {
+             CheepId = 2,
+             Author = author2,
+             AuthorId = author2.AuthorId,
+             Text = "Dependency Injections are very important.",
+             TimeStamp = DateTimeOffset.FromUnixTimeSeconds(1690992208).UtcDateTime // Ensure this matches the format in your model
+         };
+         var cheep3 = new Cheep
+         {
+             CheepId = 3,
+             Author = author1,
+             AuthorId = author1.AuthorId,
+             Text = "I like my cold brewed tee very much.",
+             TimeStamp = DateTimeOffset.FromUnixTimeSeconds(1691992208).UtcDateTime // Ensure this matches the format in your model
+         };
+         var cheep4 = new Cheep
+         {
+             CheepId = 4,
+             Author = author2,
+             AuthorId = author2.AuthorId,
+             Text = "EF Core is goated!!.",
+             TimeStamp = DateTimeOffset.FromUnixTimeSeconds(1692992208).UtcDateTime // Ensure this matches the format in your model
+         };
+         
+         context.Authors.Add(author1);
+         context.Authors.Add(author2);
+         context.Cheeps.Add(cheep1);
+         context.Cheeps.Add(cheep2);
+         context.Cheeps.Add(cheep3);
+         context.Cheeps.Add(cheep4);
+         await context.SaveChangesAsync();  // Save the seed data to the in-memory database
+
+        
+         ICheepRepository repository = new CheepRepository(context);
+         
+            // Act
+            await repository.DeleteCheepByAuthor(new AuthorDTO { Name = "Helge", Email = "helge@hotmail" });
+            await repository.DeleteCheepByAuthor(new AuthorDTO { Name = "Adrian", Email = "" });
+            
+            var cheepList = await repository.ReadAllCheeps(0);
+         
+     
+        
+            // Assert
+            Assert.True(cheepList.Count() == 0);
+         
+     }
+
+     [Fact]
+     public async void DeleteCheepsById()
+     {
+         // Arrange
+         using var connection = new SqliteConnection("Filename=:memory:");
+         await connection.OpenAsync();
+         var builder = new DbContextOptionsBuilder<CheepDBContext>().UseSqlite(connection);
+
+         using var context = new CheepDBContext(builder.Options);
+         await context.Database.EnsureCreatedAsync();
+
+         // Seed the database with a test entry
+         var author1 = new Author() { AuthorId = 1, Cheeps = null, Email = "helge@hotmail", Name = "Helge" };
+         var author2 = new Author() { AuthorId = 2, Cheeps = null, Email = "", Name = "Adrian" };
+
+         var cheep1 = new Cheep
+         {
+             CheepId = 1,
+             Author = author1,
+             AuthorId = author1.AuthorId,
+             Text = "Sådan!",
+             TimeStamp = DateTimeOffset.FromUnixTimeSeconds(1690892208)
+                 .UtcDateTime // Ensure this matches the format in your model
+         };
+         context.Authors.Add(author1);
+         context.Cheeps.Add(cheep1);
+         ICheepRepository repository = new CheepRepository(context);
+         
+         await repository.DeleteCheep(1);
+         var cheepList = await repository.ReadAllCheeps(0);
+         
+         
+         // Assert
+         Assert.True(cheepList.Count() == 0);
+     }
+
+
+
+     private static String UnixTimeStampToDateTimeString(double unixTimeStamp)
     {
         // Unix timestamp is seconds past epoch
         DateTime dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);

--- a/test/Chirp.TestUnit/UnitTests.cs
+++ b/test/Chirp.TestUnit/UnitTests.cs
@@ -222,6 +222,149 @@ public class UnitTests
          // Assert
          Assert.True(cheepList.Count() == 0);
      }
+     
+     
+     [Fact]
+     public async void DeleteCheepsByAuthorWith2Authors()
+     {
+         // Arrange
+         using var connection = new SqliteConnection("Filename=:memory:");
+         await connection.OpenAsync();                              
+         var builder = new DbContextOptionsBuilder<CheepDBContext>().UseSqlite(connection);
+                                                           
+         using var context = new CheepDBContext(builder.Options);   
+         await context.Database.EnsureCreatedAsync();               
+        
+         // Seed the database with a test entry
+         var author1 = new Author() { AuthorId = 1, Cheeps = null, Email = "helge@hotmail", Name = "Helge" };
+         var author2 = new Author() { AuthorId = 2, Cheeps = null, Email = "", Name = "Adrian" };
+         
+         var cheep1 = new Cheep
+         {
+             CheepId = 1,
+             Author = author1,
+             AuthorId = author1.AuthorId,
+             Text = "Sådan!",
+             TimeStamp = DateTimeOffset.FromUnixTimeSeconds(1690892208).UtcDateTime // Ensure this matches the format in your model
+         };
+         var cheep2 = new Cheep
+         {
+             CheepId = 2,
+             Author = author2,
+             AuthorId = author2.AuthorId,
+             Text = "Dependency Injections are very important.",
+             TimeStamp = DateTimeOffset.FromUnixTimeSeconds(1690992208).UtcDateTime // Ensure this matches the format in your model
+         };
+         var cheep3 = new Cheep
+         {
+             CheepId = 3,
+             Author = author1,
+             AuthorId = author1.AuthorId,
+             Text = "I like my cold brewed tee very much.",
+             TimeStamp = DateTimeOffset.FromUnixTimeSeconds(1691992208).UtcDateTime // Ensure this matches the format in your model
+         };
+         var cheep4 = new Cheep
+         {
+             CheepId = 4,
+             Author = author2,
+             AuthorId = author2.AuthorId,
+             Text = "EF Core is goated!!.",
+             TimeStamp = DateTimeOffset.FromUnixTimeSeconds(1692992208).UtcDateTime // Ensure this matches the format in your model
+         };
+         
+         context.Authors.Add(author1);
+         context.Authors.Add(author2);
+         context.Cheeps.Add(cheep1);
+         context.Cheeps.Add(cheep2);
+         context.Cheeps.Add(cheep3);
+         context.Cheeps.Add(cheep4);
+         await context.SaveChangesAsync();  // Save the seed data to the in-memory database
+
+        
+         ICheepRepository repository = new CheepRepository(context);
+         
+            // Act
+            await repository.DeleteCheepByAuthor(new AuthorDTO { Name = "Helge", Email = "helge@hotmail" });
+            
+            
+            var cheepList = await repository.ReadAllCheeps(0);
+         
+     
+        
+            // Assert
+            Assert.True(cheepList.Count() == 2);
+            // chek if the cheep with author helge is deleted
+     }
+      [Fact]
+     public async void DeleteCheepsByIdMultipleCheepsr()
+     {
+         // Arrange
+         using var connection = new SqliteConnection("Filename=:memory:");
+         await connection.OpenAsync();                              
+         var builder = new DbContextOptionsBuilder<CheepDBContext>().UseSqlite(connection);
+                                                           
+         using var context = new CheepDBContext(builder.Options);   
+         await context.Database.EnsureCreatedAsync();               
+        
+         // Seed the database with a test entry
+         var author1 = new Author() { AuthorId = 1, Cheeps = null, Email = "helge@hotmail", Name = "Helge" };
+         var author2 = new Author() { AuthorId = 2, Cheeps = null, Email = "", Name = "Adrian" };
+         
+         var cheep1 = new Cheep
+         {
+             CheepId = 1,
+             Author = author1,
+             AuthorId = author1.AuthorId,
+             Text = "Sådan!",
+             TimeStamp = DateTimeOffset.FromUnixTimeSeconds(1690892208).UtcDateTime // Ensure this matches the format in your model
+         };
+         var cheep2 = new Cheep
+         {
+             CheepId = 2,
+             Author = author2,
+             AuthorId = author2.AuthorId,
+             Text = "Dependency Injections are very important.",
+             TimeStamp = DateTimeOffset.FromUnixTimeSeconds(1690992208).UtcDateTime // Ensure this matches the format in your model
+         };
+         var cheep3 = new Cheep
+         {
+             CheepId = 3,
+             Author = author1,
+             AuthorId = author1.AuthorId,
+             Text = "I like my cold brewed tee very much.",
+             TimeStamp = DateTimeOffset.FromUnixTimeSeconds(1691992208).UtcDateTime // Ensure this matches the format in your model
+         };
+         var cheep4 = new Cheep
+         {
+             CheepId = 4,
+             Author = author2,
+             AuthorId = author2.AuthorId,
+             Text = "EF Core is goated!!.",
+             TimeStamp = DateTimeOffset.FromUnixTimeSeconds(1692992208).UtcDateTime // Ensure this matches the format in your model
+         };
+         
+         context.Authors.Add(author1);
+         context.Authors.Add(author2);
+         context.Cheeps.Add(cheep1);
+         context.Cheeps.Add(cheep2);
+         context.Cheeps.Add(cheep3);
+         context.Cheeps.Add(cheep4);
+         await context.SaveChangesAsync();  // Save the seed data to the in-memory database
+
+        
+         ICheepRepository repository = new CheepRepository(context);
+         
+            // Act
+            await repository.DeleteCheep(1);
+            
+            var cheepList = await repository.ReadAllCheeps(0);
+         
+            
+        
+            // Assert
+            Assert.True(cheepList.Count() == 3);
+         
+     }
 
 
 


### PR DESCRIPTION
# Deleting User Data and Account Now Deletes all the user's Cheeps

### Things That I have Done
- Added a Method in the backend for deleting all cheeps from an author, and deleting them by ID
-  Added the method To the Pipeline such that It can be reached from the frontend
-  Scaffolded the page handling user deletion and added a call to the method for deleting all cheeps when user is deleted
-  Added multiple E2E tests for Testing that cheeps are being posted of the Correct Length, Not Empty and are being properly deleted after Test
-  Added Unit Test sfor testing that we actually can delete all from a single author and multiple
-  Added Unit Test for testing the deletion of Cheeps By Id


### This should have solved the Issue Ticket #127 For deleting Cheeps