### PR TITLE
Resolved warnings from current main

### DIFF
--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -59,7 +59,7 @@ namespace Chirp.Infrastructure.Repositories
             return await query.ToListAsync();
         }
         // get total count of pages 
-        public async Task<int> GetTotalPages(string authorName = null)
+        public async Task<int> GetTotalPages(string authorName = "")
         {
             var query = _dbContext.Cheeps.AsQueryable();
             
@@ -86,15 +86,19 @@ namespace Chirp.Infrastructure.Repositories
             }
 
             // Create a new Cheep 
-            Cheep newCheep = new Cheep
+            if (author != null)
             {
-                Text = cheepDTO.Text,
-                Author =  author,
-                TimeStamp = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time"))
-            };
+                Cheep newCheep = new Cheep
+                {
+                    Text = cheepDTO.Text,
+                    Author =  author,
+                    TimeStamp = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time"))
+                };
 
-            // Add the new Cheep to the DbContext
-            await _dbContext.Cheeps.AddAsync(newCheep);
+                // Add the new Cheep to the DbContext
+                await _dbContext.Cheeps.AddAsync(newCheep);
+            }
+
             await _dbContext.SaveChangesAsync(); // Persist the changes to the database
         }
 

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -14,7 +14,7 @@
     <div class="timeline-header">
         <h2> Public Timeline </h2>
     </div>
-    @if(User.Identity.IsAuthenticated){ 
+    @if(User.Identity != null && User.Identity.IsAuthenticated){ 
         @* Render the Share Form Partial View *@
         @await Html.PartialAsync("_ShareCheepForm", Model.SharedChirpView)
     }

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -1,4 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Text;
 using Chirp.Core.DTOs;
 using Chirp.Infrastructure.Services;
 using Chirp.Web.Pages.Views;
@@ -15,7 +17,7 @@ public class PublicModel : PageModel
     public int TotalPageNumber { get; set; }
 
     public required List<CheepDTO> Cheeps { get; set; } = new List<CheepDTO>();
-    public SharedChirpViewModel SharedChirpView { get; set; } = new SharedChirpViewModel { FormAction = "/Public" };
+    public SharedChirpViewModel SharedChirpView { get; set; } = new SharedChirpViewModel();
 
     public PublicModel(CheepService service)
     {
@@ -32,18 +34,18 @@ public class PublicModel : PageModel
         {
             page = 1;
         }
-        
+
         PageNumber = page;
         Cheeps = await _service.GetCheeps(page);
         TotalPageNumber = await _service.GetTotalPageNumber();
-        
+
         return Page();
     }
 
     [BindProperty]
     [Required(ErrorMessage = "At least write something before you click me....")]
     [StringLength(160, ErrorMessage = "Maximum length is {1} characters")]
-    public string CheepText { get; set; }
+    public string CheepText { get; set; } = string.Empty;
     public async Task<IActionResult> OnPost()
     {
         if (!ModelState.IsValid) // Check if the model state is invalid
@@ -53,27 +55,30 @@ public class PublicModel : PageModel
             TotalPageNumber = await _service.GetTotalPageNumber();
             return Page(); // Return the page with validation messages
         }
-        
+
         if (User.Identity != null && User.Identity.IsAuthenticated)
         {
             var authorName = User.Identity.Name;
             var authorEmail = User.Identity.Name;
 
-            // Create the new CheepDTO
-            var cheepDTO = new CheepDTO
+            if (authorName != null && authorEmail != null)
             {
-                Author = new AuthorDTO
+                // Create the new CheepDTO
+                var cheepDTO = new CheepDTO
                 {
-                    Name = authorName, // this needs to be changed to user names going forward
-                    Email = authorEmail 
-                },
-                Text = CheepText,
-                FormattedTimeStamp = DateTime.UtcNow.ToString() // Or however you want to format this
-            };
+                    Author = new AuthorDTO
+                    {
+                        Name = authorName, // this needs to be changed to user names going forward
+                        Email = authorEmail
+                    },
+                    Text = CheepText,
+                    FormattedTimeStamp = DateTime.UtcNow.ToString(CultureInfo.CurrentCulture) // Or however you want to format this
+                };
 
-            await _service.CreateCheep(cheepDTO);
+                await _service.CreateCheep(cheepDTO);
+            }
         }
-        
+
         return RedirectToPage("Public", new { page = 1 });
     }
 }

--- a/src/Chirp.Web/Pages/Shared/_ShareCheepForm.cshtml
+++ b/src/Chirp.Web/Pages/Shared/_ShareCheepForm.cshtml
@@ -17,7 +17,7 @@
     @* <h3>What's on your mind @(User.Identity?.Name)?</h3> *@
     @if (User.Identity != null && !string.IsNullOrEmpty(User.Identity.Name))
     {
-    <h3>What's on your mind, @User.Identity.Name?</h3>
+    <h3>What's on your mind @User.Identity.Name?</h3>
     }
     else
     {

--- a/src/Chirp.Web/Pages/Shared/_ShareCheepForm.cshtml
+++ b/src/Chirp.Web/Pages/Shared/_ShareCheepForm.cshtml
@@ -14,12 +14,20 @@
 @model Chirp.Web.Pages.Views.SharedChirpViewModel
 
 <div class="cheepbox">
-    <h3>What's on your mind @(User.Identity.Name)?</h3>
+    @* <h3>What's on your mind @(User.Identity?.Name)?</h3> *@
+    @if (User.Identity != null && !string.IsNullOrEmpty(User.Identity.Name))
+    {
+    <h3>What's on your mind, @User.Identity.Name?</h3>
+    }
+    else
+    {
+    <h3>What's on your mind?</h3>
+    }
     <form asp-page="SubmitCheep">
         <input style="float: left" type="text" asp-for="CheepText">
         <input type="submit" value="Share">
         <div style="clear: both;"></div> <!-- Clears float -->
         <span asp-validation-for="CheepText" class="text-danger"></span>
-        <br />
+        <br/>
     </form>
 </div>

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -16,7 +16,7 @@
         </a>
         <h2> @authorName's Timeline </h2>
     </div>
-    @if(User.Identity.IsAuthenticated){
+    @if(User.Identity != null && User.Identity.IsAuthenticated){
         @* Render the Share Form Partial View *@
         @await Html.PartialAsync("_ShareCheepForm", Model.SharedViewModel)
     }

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using Chirp.Core.DTOs;
 using Chirp.Infrastructure.Services;
 using Chirp.Web.Pages.Views;
@@ -15,7 +16,7 @@ public class UserTimelineModel : PageModel
     public int TotalPageNumber { get; set; }
     public SharedChirpViewModel SharedViewModel { get; set; } = new SharedChirpViewModel();
     public required List<CheepDTO> Cheeps { get; set; }
-    public string CurrentAuthor;
+    public string CurrentAuthor = string.Empty;
     public UserTimelineModel(CheepService service)
     {
         _service = service;
@@ -39,8 +40,7 @@ public class UserTimelineModel : PageModel
     [BindProperty]
     [Required(ErrorMessage = "At least write something before you click me....")]
     [StringLength(160, ErrorMessage = "Maximum length is {1}")]
-    [Display(Name = "Message Text")]
-    public string CheepText { get; set; }
+    public string CheepText { get; set; } = string.Empty; 
     public async Task<IActionResult> OnPost()
     {
         if (!ModelState.IsValid) // Check if the model state is invalid
@@ -51,26 +51,35 @@ public class UserTimelineModel : PageModel
             return Page(); // Return the page with validation messages
         }
         
-        if (User.Identity.IsAuthenticated)
+        if (User.Identity != null && User.Identity.IsAuthenticated)
         {
             var authorName = User.Identity.Name;
             var authorEmail = User.Identity.Name;
 
-            // Create the new CheepDTO
-            var cheepDTO = new CheepDTO
+            if (authorName != null && authorEmail != null)
             {
-                Author = new AuthorDTO
+                // Create the new CheepDTO
+                var cheepDTO = new CheepDTO
                 {
-                    Name = authorName, // this needs to be changed to user names going forward
-                    Email = authorEmail 
-                },
-                Text = CheepText,
-                FormattedTimeStamp = DateTime.UtcNow.ToString() // Or however you want to format this
-            };
+                    Author = new AuthorDTO
+                    {
+                        Name = authorName, // this needs to be changed to user names going forward
+                        Email = authorEmail
+                    },
+                    Text = CheepText,
+                    FormattedTimeStamp =
+                        DateTime.UtcNow.ToString(CultureInfo.CurrentCulture) // Or however you want to format this
+                };
 
-            await _service.CreateCheep(cheepDTO);
+                await _service.CreateCheep(cheepDTO);
+            }
         }
 
-        return RedirectToPage("UserTimeline", new { author = User.Identity.Name, page = 1 });
+        if (User.Identity != null)
+        {
+            return RedirectToPage("UserTimeline", new { author = User.Identity.Name, page = 1 });
+        } else {
+            return RedirectToPage("Public", new { page = 1 });
+        }
     }
 }

--- a/src/Chirp.Web/Pages/Views/SharedChirpViewModel.cs
+++ b/src/Chirp.Web/Pages/Views/SharedChirpViewModel.cs
@@ -6,6 +6,6 @@ namespace Chirp.Web.Pages.Views;
 
 public class SharedChirpViewModel
 {
-    public string FormAction { get; set; }
-    public string CheepText { get; set; }
+    // public string FormAction { get; set; }
+    public string CheepText { get; set; } = string.Empty;
 }

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -98,7 +98,7 @@ namespace Chirp.Web
             app.Use(async (context, next) =>
             {
                 // The Content-Security-Policy header helps to protect the webapp from XSS attacks
-                context.Response.Headers.Add("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self';");
+                context.Response.Headers.Append("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self';");
                 await next();
             });
 

--- a/test/Chirp.TestE2E/E2ETests.cs
+++ b/test/Chirp.TestE2E/E2ETests.cs
@@ -776,14 +776,14 @@ public class E2ETests : PageTest
             
             await _page.GetByRole(AriaRole.Link, new() { Name = "public timeline" }).ClickAsync();
             await _page.Locator("#CheepText").ClickAsync();
-            await _page.Locator("#CheepText").FillAsync("Hello World!");
+            await _page.Locator("#CheepText").FillAsync("HelloWorld!RasmusMathiasNikolajMarcusErTelos!");
             await _page.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
             // Clean up and delete data
             await DeleteUser();   
             
             // check that the cheep is deleted
             await _page.GetByRole(AriaRole.Link, new() { Name = "public timeline" }).ClickAsync();
-            await Expect(_page.Locator("li").Filter(new() { HasText = "Hello World!" }).First).Not.ToBeVisibleAsync();
+            await Expect(_page.Locator("li").Filter(new() { HasText = "HelloWorld!RasmusMathiasNikolajMarcusErTelos!" }).First).Not.ToBeVisibleAsync();
         }
     }
 }


### PR DESCRIPTION
The following warnings appeared when running ``dotnet watch``:
CS8625 (Cannot convert null literal to non-nullable reference type): 1 warning.
CS8601 (Possible null reference assignment): 5 warnings.
CS8618 (Non-nullable property/field must contain a non-null value when exiting constructor): 5 warnings.
CS8602 (Dereference of a possibly null reference): 5 warnings.
ASP0019 (Use appropriate header methods in ASP.NET Core): 1 warning

Many of the warnings were due to us not checking, if the value of a string was null before handling, or initializing strings with an initial value of null. Much of this was solved by adding a condition to check the value of the variable beforehand and initializing some varibles with an empty string. Ex:

- Instead of "adding" context security policy header, I now append instead. 
- Strings that threw a non nullable warning is now initialized with a value of empty string to keep non nullable property for CheepText and Author.