### PR TITLE
Fixing redirects and proper population of cheeps

### DIFF
--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -61,9 +61,11 @@ public class UserTimelineModel : PageModel
     {
         string? currentAuthor = RouteData.Values["author"]?.ToString();
         CurrentAuthor = currentAuthor;
+
+        userAuthor = await _service.FindAuthorByName(CurrentAuthor);
         
         PageNumber = 1;
-        TotalPageNumber = await _service.GetTotalPageNumber(currentAuthor);
+        TotalPageNumber = await _service.GetTotalPageNumber(CurrentAuthor);
         
         if (!ModelState.IsValid) // Check if the model state is invalid
         {

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -17,7 +17,7 @@ public class UserTimelineModel : PageModel
     public int TotalPageNumber { get; set; }
     public SharedChirpViewModel SharedViewModel { get; set; } = new SharedChirpViewModel();
     public required List<CheepDTO> Cheeps { get; set; }
-    public string CurrentAuthor = string.Empty;
+    public string CurrentAuthor { get; set; } = string.Empty;
     public UserTimelineModel(CheepService service)
     {
         _service = service;
@@ -59,6 +59,12 @@ public class UserTimelineModel : PageModel
     public string CheepText { get; set; } = string.Empty; 
     public async Task<IActionResult> OnPost()
     {
+        string? currentAuthor = RouteData.Values["author"]?.ToString();
+        CurrentAuthor = currentAuthor;
+        
+        PageNumber = 1;
+        TotalPageNumber = await _service.GetTotalPageNumber(currentAuthor);
+        
         if (!ModelState.IsValid) // Check if the model state is invalid
         {
             // Ensure Cheeps and other required properties are populated
@@ -68,7 +74,6 @@ public class UserTimelineModel : PageModel
             } else {
                 Cheeps = await _service.GetCheepsFromAuthor(CurrentAuthor, PageNumber); 
             }
-            TotalPageNumber = await _service.GetTotalPageNumber();
             return Page(); // Return the page with validation messages
         }
         
@@ -96,6 +101,10 @@ public class UserTimelineModel : PageModel
             }
         }
 
+        // Returns to the authors timeline
+        // return RedirectToPage("UserTimeline", new { author = currentAuthor, page = 1 });
+        
+        // Returns to the users timeline
         return RedirectToPage("UserTimeline", new { author = User.Identity.Name, page = 1 });
     }
     
@@ -112,6 +121,8 @@ public class UserTimelineModel : PageModel
             await _service.FollowAuthor(userAuthor, followedAuthorName);
             
         }
+        
+        return RedirectToPage("UserTimeline", new { author = RouteData.Values["author"]?.ToString(), page = "1" });
         return RedirectToPage("UserTimeline", new { author = User.Identity.Name, page = 1 });
     }
 
@@ -128,7 +139,8 @@ public class UserTimelineModel : PageModel
             await _service.UnfollowAuthor(userAuthor, followedAuthor);
             
         }
-
+        
+        return RedirectToPage("UserTimeline", new { author = RouteData.Values["author"]?.ToString(), page = "1" });
         return RedirectToPage("UserTimeline", new { author = User.Identity.Name, page = 1 });
     }
 }

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -62,7 +62,7 @@ public class UserTimelineModel : PageModel
         string? currentAuthor = RouteData.Values["author"]?.ToString();
         CurrentAuthor = currentAuthor;
 
-        userAuthor = await _service.FindAuthorByName(CurrentAuthor);
+        userAuthor = await _service.FindAuthorByName(User.Identity.Name);
         
         PageNumber = 1;
         TotalPageNumber = await _service.GetTotalPageNumber(CurrentAuthor);
@@ -125,7 +125,6 @@ public class UserTimelineModel : PageModel
         }
         
         return RedirectToPage("UserTimeline", new { author = RouteData.Values["author"]?.ToString(), page = "1" });
-        return RedirectToPage("UserTimeline", new { author = User.Identity.Name, page = 1 });
     }
 
     /// <summary>
@@ -143,6 +142,5 @@ public class UserTimelineModel : PageModel
         }
         
         return RedirectToPage("UserTimeline", new { author = RouteData.Values["author"]?.ToString(), page = "1" });
-        return RedirectToPage("UserTimeline", new { author = User.Identity.Name, page = 1 });
     }
 }


### PR DESCRIPTION
Jeg er for træt til at skrive på engelsk, så i får den på dansk.

Når man kører `onPost` så gemte den ikke states, såsom `userAuthor`, `page` og `maxPage`. Derfor så skulle variablerne fra `onGet` også defineres i `onPost` metoden. Nu bliver de korrekte cheeps og den korrekte side og max side vist for usertimeline.