### PR TITLE
Added a new endpoint to get the list of followers of the user + 3 new integration tests

### DIFF
--- a/src/Chirp.Core/Interfaces/IAuthorRepository.cs
+++ b/src/Chirp.Core/Interfaces/IAuthorRepository.cs
@@ -11,4 +11,5 @@ public interface IAuthorRepository
     Task FollowAuthor(string userAuthor, string followedAuthor);
     Task UnfollowAuthor(string userAuthor, string authorToBeRemoved);
     Task RemovedAuthorFromFollowingList(string authorName);
+    Task<List<string>> GetFollowedAuthors(string userName);
 }

--- a/src/Chirp.Infrastructure/Repositories/AuthorRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/AuthorRepository.cs
@@ -114,5 +114,15 @@ namespace Chirp.Infrastructure.Repositories
             
             await _dbContext.SaveChangesAsync();
         }
+        /// <summary>
+        /// Returns the list of authors that a user follows
+        /// </summary>
+        /// <param name="userName">The username from the url</param>
+        /// <returns></returns>
+        public async Task<List<string>> GetFollowedAuthors(string userName)
+        {
+            var author = await Task.Run(() => FindAuthorByName(userName));
+            return author?.AuthorsFollowed.ToList() ?? new List<string>();
+        }
     }    
 }

--- a/src/Chirp.Infrastructure/Services/CheepService.cs
+++ b/src/Chirp.Infrastructure/Services/CheepService.cs
@@ -17,6 +17,8 @@ public interface ICheepService
     public Task<List<Core.DTOs.CheepDTO>> RetrieveAllCheepsFromAnAuthor(string authorName);
    
     public Task DeleteUserCheeps(AuthorDTO Author);
+    
+    public Task <List<string>>GetFollowedAuthors(string userName);
 }
 public class CheepService : ICheepService
 {
@@ -98,5 +100,9 @@ public class CheepService : ICheepService
     public async Task RemovedAuthorFromFollowingList(string authorName)
     {
         await _authorRepository.RemovedAuthorFromFollowingList(authorName);
+    }
+    public async Task<List<string>> GetFollowedAuthors(string userName)
+    {
+        return await _authorRepository.GetFollowedAuthors(userName);
     }
 }

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -176,6 +176,12 @@ namespace Chirp.Web
                 return Results.Ok(cheeps);
             });
             
+            app.MapGet("/{userName}/follows", async (string userName, CheepService cheepService) =>
+            {
+                var followedAuthors = await cheepService.GetFollowedAuthors(userName);
+                return Results.Ok(followedAuthors);
+            });
+            
             // Run the application
             app.Run();
         }


### PR DESCRIPTION
## Things added for the pull request

### New endpoint
A user can now write /follows after they are either in their own user timeline, or a different author's timeline. It will then output a list using JSON, which outputs all the authors the user itself follows or the author itself follows (depending on the scenario). The endpoint is added in Program.cs

### New methods
A new method in CheepService & AuthorRepository is added, which returns the authorsFollowed List of the author. 

### 3 new integration tests
- CheckGetFollowsWhenEmpty(): Checks if the list returned at the endpoint loads when there are no authors followed
- CheckGetFollowsWhenFollowing(): Follows a test author, and checks if the test author is at the endpoint
- CheckGetFollowsAfterUnfollowing(): Follows and then unfollows the same test author, and checks that the list does not contain the test author anymore
