### PR TITLE
Quick fix

### DIFF
--- a/src/Chirp.Web/wwwroot/css/style.css
+++ b/src/Chirp.Web/wwwroot/css/style.css
@@ -7,6 +7,7 @@ body {
     background-repeat: no-repeat, no-repeat;  /* No repetition for both images */
     background-size: 100% 85%, 100% auto;  /* Stretch gradient vertically and maintain aspect ratio for image */
     
+    min-height: 100vh;
     font-family: 'Trebuchet MS', sans-serif;
     font-size: 14px;
 }


### PR DESCRIPTION
Quick fix by adding min-height: 100vh; to ensure that the background fills out the viewport.

There is no longer any white space but the background images are cutting each other off when visiting timelines or pages with low height. Spent a couple hours debugging but can't seem to get it to work. So this will do for now.