### PR TITLE
Image and GIF UPLOAD FEATURE!

### DIFF
--- a/src/Chirp.Core/Chirp.Core.csproj
+++ b/src/Chirp.Core/Chirp.Core.csproj
@@ -7,4 +7,10 @@
         <RootNamespace>Chirp.Core</RootNamespace>
     </PropertyGroup>
 
+    <ItemGroup>
+      <Reference Include="Microsoft.AspNetCore.Http.Features">
+        <HintPath>..\..\..\..\..\..\..\..\Program Files\dotnet\shared\Microsoft.AspNetCore.App\8.0.11\Microsoft.AspNetCore.Http.Features.dll</HintPath>
+      </Reference>
+    </ItemGroup>
+
 </Project>

--- a/src/Chirp.Core/DTOs/CheepDTO.cs
+++ b/src/Chirp.Core/DTOs/CheepDTO.cs
@@ -1,4 +1,6 @@
-﻿namespace Chirp.Core.DTOs;
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Chirp.Core.DTOs;
 
 public class CheepDTO
 {

--- a/src/Chirp.Core/Interfaces/ICheepRepository.cs
+++ b/src/Chirp.Core/Interfaces/ICheepRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Chirp.Core.DTOs;
+using Microsoft.AspNetCore.Http;
 
 namespace Chirp.Core.Interfaces;
 
@@ -13,4 +14,5 @@ public interface ICheepRepository
     Task DeleteUserCheeps(AuthorDTO author);
     public Task<List<CheepDTO>> GetPopularCheeps(int page);
     Task<int> GetTotalPageNumberForPopular();
+    Task<string> HandleImageUpload(IFormFile image);
 }

--- a/src/Chirp.Infrastructure/Chirp.Infrastructure.csproj
+++ b/src/Chirp.Infrastructure/Chirp.Infrastructure.csproj
@@ -8,26 +8,27 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Content Include="Migrations\**\*.*" CopyToPublishDirectory="PreserveNewest"/>
+        <Content Include="Migrations\**\*.*" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="8.2.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-rc.2.24474.1"/>
+        <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="8.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-rc.2.24474.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-rc.2.24474.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Chirp.Core\Chirp.Core.csproj"/>
+        <ProjectReference Include="..\Chirp.Core\Chirp.Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Chirp.Infrastructure/Chirp.Infrastructure.csproj
+++ b/src/Chirp.Infrastructure/Chirp.Infrastructure.csproj
@@ -13,6 +13,7 @@
 
     <ItemGroup>
         <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="8.2.0" />
+        <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.2.0" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-rc.2.24474.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-rc.2.24474.1">

--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -453,29 +453,5 @@ namespace Chirp.Infrastructure.Repositories
             return base64;
         }
         
-        /*public static IFormFile DecodeBase64ToImage(string base64)
-        {
-            // Convert base64 to IFormFile
-            if (string.IsNullOrEmpty(base64))
-            {
-                return null;
-            }
-
-            // Convert base64 to byte array
-            var imageBytes = Convert.FromBase64String(base64);
-
-            // Create a memory stream from the byte array
-            var ms = new MemoryStream(imageBytes);
-
-            // Create a file from the memory stream
-            var formFile = new FormFile(ms, 0, ms.Length, "file", "image.jpg") // You can specify any filename and content type
-            {
-                Headers = new HeaderDictionary(),
-                ContentType = "image/png" // You can adjust the content type depending on the image format
-            };
-
-            return formFile;
-        }*/
-        
     }
 }

--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -441,6 +441,12 @@ namespace Chirp.Infrastructure.Repositories
 
         public async Task<string> HandleImageUpload(IFormFile image)
         {
+            // Check if the file is a GIF
+            if(image.ContentType == "image/gif")
+            {
+                return await EncodeToBase64(image);
+            }
+            
             // Compress the image and get the byte array
             var compressedImageBytes = await CompressImage(image);
     

--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -430,6 +430,7 @@ namespace Chirp.Infrastructure.Repositories
                         AuthorsFollowed = cheep.Author.AuthorsFollowed
                     },
                     Text = cheep.Text,
+                    ImageReference = cheep.ImageReference,
                     FormattedTimeStamp = cheep.TimeStamp.ToString("yyyy-MM-dd HH:mm:ss"),
                     Likes = cheep.Likes,
                     Dislikes = cheep.Dislikes,
@@ -455,20 +456,6 @@ namespace Chirp.Infrastructure.Repositories
             // Convert the byte array to base64 string
             var base64String = Convert.ToBase64String(compressedImageBytes);
             return base64String;
-        }
-
-        public async Task<string> EncodeToBase64(IFormFile image)
-        {
-            var base64 = "";
-            
-            if (image != null && image.Length > 0)
-            {
-                using var ms = new MemoryStream();
-                image.CopyTo(ms);
-                var fileBytes = ms.ToArray();
-                base64 = Convert.ToBase64String(fileBytes);
-            }
-            return base64;
         }
         
         public async Task<byte[]> CompressImage(IFormFile image)

--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -37,6 +37,7 @@ namespace Chirp.Infrastructure.Repositories
                         AuthorsFollowed = cheep.Author.AuthorsFollowed
                     },
                     Text = cheep.Text,
+                    ImageReference = cheep.ImageReference,
                     FormattedTimeStamp = cheep.TimeStamp.ToString("yyyy-MM-dd HH:mm:ss"),
                     Likes = cheep.Likes,
                     Dislikes = cheep.Dislikes,
@@ -62,6 +63,7 @@ namespace Chirp.Infrastructure.Repositories
                         AuthorsFollowed = cheep.Author.AuthorsFollowed
                     },
                     Text = cheep.Text,
+                    ImageReference = cheep.ImageReference,
                     FormattedTimeStamp = cheep.TimeStamp.ToString("yyyy-MM-dd HH:mm:ss"),
                     Likes = cheep.Likes,
                     Dislikes = cheep.Dislikes,
@@ -89,6 +91,7 @@ namespace Chirp.Infrastructure.Repositories
                         AuthorsFollowed = cheep.Author.AuthorsFollowed
                     },
                     Text = cheep.Text,
+                    ImageReference = cheep.ImageReference,
                     FormattedTimeStamp = cheep.TimeStamp.ToString("yyyy-MM-dd HH:mm:ss"),
                     Likes = cheep.Likes,
                     Dislikes = cheep.Dislikes,
@@ -128,6 +131,7 @@ namespace Chirp.Infrastructure.Repositories
                         AuthorsFollowed = cheep.Author.AuthorsFollowed
                     },
                     Text = cheep.Text,
+                    ImageReference = cheep.ImageReference,
                     FormattedTimeStamp = cheep.TimeStamp.ToString("yyyy-MM-dd HH:mm:ss"),
                     Likes = cheep.Likes,
                     Dislikes = cheep.Dislikes,
@@ -448,6 +452,30 @@ namespace Chirp.Infrastructure.Repositories
             }
             return base64;
         }
+        
+        /*public static IFormFile DecodeBase64ToImage(string base64)
+        {
+            // Convert base64 to IFormFile
+            if (string.IsNullOrEmpty(base64))
+            {
+                return null;
+            }
+
+            // Convert base64 to byte array
+            var imageBytes = Convert.FromBase64String(base64);
+
+            // Create a memory stream from the byte array
+            var ms = new MemoryStream(imageBytes);
+
+            // Create a file from the memory stream
+            var formFile = new FormFile(ms, 0, ms.Length, "file", "image.jpg") // You can specify any filename and content type
+            {
+                Headers = new HeaderDictionary(),
+                ContentType = "image/png" // You can adjust the content type depending on the image format
+            };
+
+            return formFile;
+        }*/
         
     }
 }

--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -1,6 +1,7 @@
 using Chirp.Core;
 using Chirp.Core.DTOs;
 using Chirp.Core.Interfaces;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using CheepDTO = Chirp.Core.DTOs.CheepDTO;
 
@@ -207,6 +208,7 @@ namespace Chirp.Infrastructure.Repositories
                 {
                     Text = cheepDTO.Text,
                     Author = author,
+                    ImageReference = cheepDTO.ImageReference,
                     TimeStamp = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow,
                         TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time"))
                 };
@@ -429,7 +431,23 @@ namespace Chirp.Infrastructure.Repositories
 
             return await query.ToListAsync();
         }
-        
+
+        public async Task<string> HandleImageUpload(IFormFile image)
+        {
+            // Compress image
+            
+            // Convert to base64
+            var base64 = "";
+            
+            if (image != null && image.Length > 0)
+            {
+                using var ms = new MemoryStream();
+                image.CopyTo(ms);
+                var fileBytes = ms.ToArray();
+                base64 = Convert.ToBase64String(fileBytes);
+            }
+            return base64;
+        }
         
     }
 }

--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -521,12 +521,25 @@ namespace Chirp.Infrastructure.Repositories
             using var gifCollection = new MagickImageCollection(inputStream);
 
             // Step 2: Optimize the GIF frames
+            var resize = false;
+            if (gifCollection[0].Width >= 1024 || gifCollection[0].Height >= 1024)
+            {
+                resize = true;
+            } 
             foreach (var frame in gifCollection)
             {
-                frame.Resize(1024, 1024); // Resize to max dimensions
+                if (resize)
+                {
+                    frame.Resize(1024, 1024); // Resize to max dimensions
+                }
                 frame.Strip(); // Remove unnecessary metadata
+                frame.Quantize(new QuantizeSettings
+                {
+                    Colors = 128 // Limit the number of colors to control size
+                });
             }
-
+            
+            
             // Reduce file size by optimizing color palette and frames
             gifCollection.Optimize();
 

--- a/src/Chirp.Infrastructure/Services/CheepService.cs
+++ b/src/Chirp.Infrastructure/Services/CheepService.cs
@@ -1,6 +1,7 @@
 using Chirp.Core;
 using Chirp.Core.DTOs;
 using Chirp.Infrastructure.Repositories;
+using Microsoft.AspNetCore.Http;
 
 namespace Chirp.Infrastructure.Services;
 public interface ICheepService
@@ -23,7 +24,7 @@ public interface ICheepService
     public Task HandleDislike(string authorName, int cheepId);
     public Task<List<CheepDTO>> GetPopularCheeps(int page);
     public Task<int> GetTotalPageNumberForPopular();
-
+    public Task<string> HandleImageUpload(IFormFile image);
 }
 public class CheepService : ICheepService
 {
@@ -140,5 +141,10 @@ public class CheepService : ICheepService
     public async Task<int> GetTotalPageNumberForPopular()
     {
         return await _cheepRepository.GetTotalPageNumberForPopular();
+    }
+
+    public async Task<string> HandleImageUpload(IFormFile image)
+    {
+        return await _cheepRepository.HandleImageUpload(image);
     }
 }

--- a/src/Chirp.Web/Pages/PopularTimeline.cshtml
+++ b/src/Chirp.Web/Pages/PopularTimeline.cshtml
@@ -64,6 +64,17 @@
                     <small>@cheep.FormattedTimeStamp</small>
                     <br>
                     <p>@cheep.Text</p>
+                    <div>
+                        @* If image reference is not null then make an image element *@
+                        @if (cheep.ImageReference != null)
+                        {
+                            // (R0lGODlh) Is what all base64 encoded GIFs start with
+                            string mimeType = cheep.ImageReference.StartsWith("R0lGODlh") ? "image/gif" : "image/png";
+                            <a href="data:@mimeType;base64,@cheep.ImageReference" style="cursor: pointer;">
+                                <img src="data:@mimeType;base64,@cheep.ImageReference" alt="Cheep Image"/>
+                            </a>
+                        }
+                    </div>
                     <div class="CheepReactions">
                         @if (User.Identity.IsAuthenticated)
                         {

--- a/src/Chirp.Web/Pages/PopularTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/PopularTimeline.cshtml.cs
@@ -59,6 +59,8 @@ public class PopularTimelineModel : PageModel
     [Required(ErrorMessage = "At least write something before you click me....")]
     [StringLength(160, ErrorMessage = "Maximum length is {1} characters")]
     public string CheepText { get; set; } = string.Empty;
+    [BindProperty]
+    public IFormFile CheepImage { get; set; }
     public async Task<IActionResult> OnPost()
     {
         
@@ -85,6 +87,12 @@ public class PopularTimelineModel : PageModel
 
             if (authorName != null && authorEmail != null)
             {
+                string imageBase64 = null;
+                if (CheepImage != null && CheepImage.Length > 0)
+                {
+                    imageBase64 = await _service.HandleImageUpload(CheepImage);
+                }
+                
                 // Create the new CheepDTO
                 var cheepDTO = new CheepDTO
                 {
@@ -94,6 +102,7 @@ public class PopularTimelineModel : PageModel
                         Email = authorEmail
                     },
                     Text = CheepText,
+                    ImageReference = imageBase64!,
                     FormattedTimeStamp = DateTime.UtcNow.ToString(CultureInfo.CurrentCulture) // Or however you want to format this
                 };
 

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -30,7 +30,10 @@
     }
     
     @await Html.PartialAsync("_CheepSorting")
-    
+    <p>her</p>
+    <img src="data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA
+    AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO
+        9TXL0Y4OHwAAAABJRU5ErkJggg==" alt="Red dot" />
     @if (Model.Cheeps.Any())
     {
         <ul id="messagelist" class="cheeps"> 
@@ -71,6 +74,13 @@
                     <small>@cheep.FormattedTimeStamp</small>
                     <br>
                     <p>@cheep.Text</p>
+                    
+                    @* If image reference is not null then make an image element *@
+                    @if (cheep.ImageReference != null)
+                    {
+                        <img src="data:image/png;base64, @cheep.ImageReference" alt="Cheep Image" style="max-width: 100%;"/>
+                    }
+                    
                     <div class="CheepReactions">
                         @if (User.Identity.IsAuthenticated)
                         {

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -30,10 +30,6 @@
     }
     
     @await Html.PartialAsync("_CheepSorting")
-    <p>her</p>
-    <img src="data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA
-    AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO
-        9TXL0Y4OHwAAAABJRU5ErkJggg==" alt="Red dot" />
     @if (Model.Cheeps.Any())
     {
         <ul id="messagelist" class="cheeps"> 
@@ -72,14 +68,14 @@
                         </div>
                     </div>
                     <small>@cheep.FormattedTimeStamp</small>
-                    <br>
-                    <p>@cheep.Text</p>
-                    
-                    @* If image reference is not null then make an image element *@
-                    @if (cheep.ImageReference != null)
-                    {
-                        <img src="data:image/png;base64, @cheep.ImageReference" alt="Cheep Image" style="max-width: 100%;"/>
-                    }
+                    <p>@cheep.Text</p><br/>
+                    <div>
+                        @* If image reference is not null then make an image element *@
+                        @if (cheep.ImageReference != null)
+                        {
+                            <img src="data:image/png;base64, @cheep.ImageReference" alt="Cheep Image"/>
+                        }
+                    </div>
                     
                     <div class="CheepReactions">
                         @if (User.Identity.IsAuthenticated)

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -73,8 +73,10 @@
                         @* If image reference is not null then make an image element *@
                         @if (cheep.ImageReference != null)
                         {
-                            <a href="data:image/png;base64,@cheep.ImageReference" style="cursor: pointer;">
-                                <img src="data:image/png;base64, @cheep.ImageReference" alt="Cheep Image"/>
+                            // (R0lGODlh) Is what all base64 encoded GIFs start with
+                            string mimeType = cheep.ImageReference.StartsWith("R0lGODlh") ? "image/gif" : "image/png";
+                            <a href="data:@mimeType;base64,@cheep.ImageReference" style="cursor: pointer;">
+                                <img src="data:@mimeType;base64,@cheep.ImageReference" alt="Cheep Image"/>
                             </a>
                         }
                     </div>

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -73,7 +73,9 @@
                         @* If image reference is not null then make an image element *@
                         @if (cheep.ImageReference != null)
                         {
-                            <img src="data:image/png;base64, @cheep.ImageReference" alt="Cheep Image"/>
+                            <a href="data:image/png;base64,@cheep.ImageReference" style="cursor: pointer;">
+                                <img src="data:image/png;base64, @cheep.ImageReference" alt="Cheep Image"/>
+                            </a>
                         }
                     </div>
                     

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -90,9 +90,10 @@ public class PublicModel : PageModel
 
             if (authorName != null && authorEmail != null)
             {
+                
                 // Handle potential image upload
                 string imageBase64 = null;
-                if (CheepImage.Length > 0)
+                if (CheepImage != null && CheepImage.Length > 0)
                 {
                     imageBase64 = await _service.HandleImageUpload(CheepImage);
                 }

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -59,6 +59,11 @@ public class PublicModel : PageModel
     [Required(ErrorMessage = "At least write something before you click me....")]
     [StringLength(160, ErrorMessage = "Maximum length is {1} characters")]
     public string CheepText { get; set; } = string.Empty;
+
+    [BindProperty]
+    public IFormFile CheepImage { get; set; }
+
+    // Add constraint to check for file not image or gif.
     public async Task<IActionResult> OnPost()
     {
         
@@ -85,6 +90,13 @@ public class PublicModel : PageModel
 
             if (authorName != null && authorEmail != null)
             {
+                // Handle potential image upload
+                string imageBase64 = null;
+                if (CheepImage.Length > 0)
+                {
+                    imageBase64 = await _service.HandleImageUpload(CheepImage);
+                }
+                    
                 // Create the new CheepDTO
                 var cheepDTO = new CheepDTO
                 {
@@ -94,9 +106,10 @@ public class PublicModel : PageModel
                         Email = authorEmail
                     },
                     Text = CheepText,
+                    ImageReference = imageBase64!,
                     FormattedTimeStamp = DateTime.UtcNow.ToString(CultureInfo.CurrentCulture) // Or however you want to format this
                 };
-
+    
                 await _service.CreateCheep(cheepDTO);
             }
         }

--- a/src/Chirp.Web/Pages/Shared/_ShareCheepForm.cshtml
+++ b/src/Chirp.Web/Pages/Shared/_ShareCheepForm.cshtml
@@ -23,12 +23,13 @@
     {
     <h3>What's on your mind?</h3>
     }
-    <form asp-page="SubmitCheep" style="display: flex; flex-wrap: wrap; align-items: center;">
+    <form asp-page="SubmitCheep" method="post" enctype="multipart/form-data" style="display: flex; flex-wrap: wrap; align-items: center;">
         <input type="text" asp-for="CheepText" style="flex: 1; margin-right: 5px;">
         <input type="hidden" name="PageNumber" value="@ViewData["pageNumber"]" />
         <input type="submit" value="Share">
         <span asp-validation-for="CheepText" class="text-danger" style="margin-left: 10px;"></span>
-        <input value="Upload Image" type="file" asp-for="CheepFile" accept="image/*,.gif" style="margin-top: 10px; flex-basis: 100%;">
+        <input value="Upload Image" type="file" asp-for="CheepImage" accept="image/*,.gif" style="margin-top: 10px; flex-basis: 100%;">
+        <span asp-validation-for="CheepImage" class="text-danger" style="margin-left: 10px;"></span>
     </form>
 
 </div>

--- a/src/Chirp.Web/Pages/Shared/_ShareCheepForm.cshtml
+++ b/src/Chirp.Web/Pages/Shared/_ShareCheepForm.cshtml
@@ -23,10 +23,12 @@
     {
     <h3>What's on your mind?</h3>
     }
-    <form asp-page="SubmitCheep" style="display: flex; align-items: center;">
+    <form asp-page="SubmitCheep" style="display: flex; flex-wrap: wrap; align-items: center;">
         <input type="text" asp-for="CheepText" style="flex: 1; margin-right: 5px;">
         <input type="hidden" name="PageNumber" value="@ViewData["pageNumber"]" />
         <input type="submit" value="Share">
         <span asp-validation-for="CheepText" class="text-danger" style="margin-left: 10px;"></span>
+        <input value="Upload Image" type="file" asp-for="CheepFile" accept="image/*,.gif" style="margin-top: 10px; flex-basis: 100%;">
     </form>
+
 </div>

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -164,6 +164,17 @@
                     
                     <br><br>
                     <p>@cheep.Text</p>
+                    <div>
+                        @* If image reference is not null then make an image element *@
+                        @if (cheep.ImageReference != null)
+                        {
+                            // (R0lGODlh) Is what all base64 encoded GIFs start with
+                            string mimeType = cheep.ImageReference.StartsWith("R0lGODlh") ? "image/gif" : "image/png";
+                            <a href="data:@mimeType;base64,@cheep.ImageReference" style="cursor: pointer;">
+                                <img src="data:@mimeType;base64,@cheep.ImageReference" alt="Cheep Image"/>
+                            </a>
+                        }
+                    </div>
                     <div class="CheepReactions">
                         @if (User.Identity.IsAuthenticated)
                         {

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -66,6 +66,8 @@ public class UserTimelineModel : PageModel
     [Required(ErrorMessage = "At least write something before you click me....")]
     [StringLength(160, ErrorMessage = "Maximum length is {1}")]
     public string CheepText { get; set; } = string.Empty; 
+    [BindProperty]
+    public IFormFile CheepImage { get; set; }
     public async Task<IActionResult> OnPost()
     {
         string? currentAuthor = RouteData.Values["author"]?.ToString();
@@ -95,6 +97,12 @@ public class UserTimelineModel : PageModel
 
             if (authorName != null && authorEmail != null)
             {
+                string imageBase64 = null;
+                if (CheepImage != null && CheepImage.Length > 0)
+                {
+                    imageBase64 = await _service.HandleImageUpload(CheepImage);
+                }
+                
                 // Create the new CheepDTO
                 var cheepDTO = new CheepDTO
                 {
@@ -104,6 +112,7 @@ public class UserTimelineModel : PageModel
                         Email = authorEmail
                     },
                     Text = CheepText,
+                    ImageReference = imageBase64!,
                     FormattedTimeStamp =
                         DateTime.UtcNow.ToString(CultureInfo.CurrentCulture) // Or however you want to format this
                 };

--- a/src/Chirp.Web/Pages/Views/SharedChirpViewModel.cs
+++ b/src/Chirp.Web/Pages/Views/SharedChirpViewModel.cs
@@ -8,5 +8,5 @@ public class SharedChirpViewModel
 {
     // public string FormAction { get; set; }
     public string CheepText { get; set; } = string.Empty;
-    public IFormFile CheepFile { get; set; }
+    public IFormFile CheepImage { get; set; }
 }

--- a/src/Chirp.Web/Pages/Views/SharedChirpViewModel.cs
+++ b/src/Chirp.Web/Pages/Views/SharedChirpViewModel.cs
@@ -8,4 +8,5 @@ public class SharedChirpViewModel
 {
     // public string FormAction { get; set; }
     public string CheepText { get; set; } = string.Empty;
+    public IFormFile CheepFile { get; set; }
 }

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -145,7 +145,7 @@ namespace Chirp.Web
                     "script-src 'self' https://bdsagroup07chirprazor.azurewebsites.net/; " +  // Allow scripts from self and Azure
                     "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; " + // Allow styles from Font Awesome CDN
                     "style-src 'self' 'unsafe-inline'; " +               // Allow inline styles and styles from self
-                    "img-src 'self'; " +                                 // Allow images from self
+                    "img-src 'self' data:; " +  // Allow images from self and Base64-encoded images
                     "script-src-elem 'self' 'unsafe-inline'; " +         // Allow inline scripts in elements
                     "connect-src 'self' ws://localhost:53540/ wss://localhost:53539/ https://bdsagroup07chirprazor.azurewebsites.net/; " + // Allow WebSocket connections from localhost and Azure
                     "font-src 'self' https://cdnjs.cloudflare.com; " + // Allow fonts from Font Awesome CDN

--- a/src/Chirp.Web/wwwroot/css/style.css
+++ b/src/Chirp.Web/wwwroot/css/style.css
@@ -171,13 +171,12 @@ div.page ul.cheeps {
 
 div.page ul.cheeps li {
     margin: 10px 0;
-    padding: 5px;
+    padding: 10px;
     background: #F0FAF9;
     border: 1px solid #DBF3F1;
-    border-radius: 2px;
-    -moz-border-radius: 5px;
-    -webkit-border-radius: 5px;
-    min-height: 48px;
+    border-radius: 5px;
+    display: flex;
+    flex-direction: column;
 }
 
 div.page ul.cheeps p {
@@ -187,8 +186,13 @@ div.page ul.cheeps p {
 }
 
 div.page ul.cheeps li img {
+    display: block; /* Ensures it takes its own line */
+    margin: 0 auto; /* Centers the image horizontally */
+    max-width: 100%; /* Ensures the image doesn't overflow the cheep container */
+    height: auto; /* Maintains aspect ratio */
+    border-radius: 5px; /* Optional: adds rounded corners */
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1); /* Optional: adds a slight shadow */
     float: left;
-    padding: 0 10px 0 0;
 }
 
 div.page ul.cheeps li small {
@@ -366,6 +370,15 @@ ul.nav li a:hover {
 
 .cheep-container > form:has(#unfollowButton) > button {
     background-color: #cc6e6e;
+}
+
+div.page ul.cheeps li img {
+    display: block; /* Ensure the image appears on its own line */
+    max-width: 100%; /* Prevent the image from exceeding the container's width */
+    height: auto; /* Maintain aspect ratio */
+    margin: 10px auto; /* Add space above and below the image, center it horizontally */
+    border-radius: 5px; /* Optional: Add rounded corners for a polished look */
+    border: 1px solid #DBF3F1; /* Optional: Add a border for better visibility */
 }
 
 .providerImg {

--- a/src/Chirp.Web/wwwroot/css/style.css
+++ b/src/Chirp.Web/wwwroot/css/style.css
@@ -616,18 +616,19 @@ ul.nav li a:hover {
 
 .show {
     display: block;
-
+}
 .Delete button {
     background-image: url("../images/trash-can-svgrepo-com.svg"); /* Path to your image */
     background-size: contain; /* Ensure the image fits within the button */
     background-position: right; /* Center the image within the button */
     background-repeat: no-repeat;
     border: none;
-    width: 25px; 
-    height: 25px; 
-    cursor: pointer; 
-    display: inline-flex; 
-    align-items: center; 
-    justify-content: center; 
-    background-color: rgba(255, 255, 255, 0); 
+    width: 25px;
+    height: 25px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(255, 255, 255, 0);
 }
+

--- a/src/Chirp.Web/wwwroot/css/style.css
+++ b/src/Chirp.Web/wwwroot/css/style.css
@@ -375,6 +375,7 @@ ul.nav li a:hover {
 div.page ul.cheeps li img {
     display: block; /* Ensure the image appears on its own line */
     max-width: 100%; /* Prevent the image from exceeding the container's width */
+    max-height: 200px;
     height: auto; /* Maintain aspect ratio */
     margin: 10px auto; /* Add space above and below the image, center it horizontally */
     border-radius: 5px; /* Optional: Add rounded corners for a polished look */


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7ccee05a-40c1-4fe7-ad22-eb19c4d19ec5)

## New feature added
Images & GIFs can now be uploaded on cheeps. The images and GIFs will also be compressed so that they don't use up much space, and also have a set size! The Gifs and images are now stored in the cheeps imagereference attribute, but as base64 instead

## New methods added
New methods added to repository and cheepservice to accomodate for GIFs and images.