### PR TITLE
Images & GIFs part of the personal data a user can download

### DIFF
--- a/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/PersonalData.cshtml
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/PersonalData.cshtml
@@ -88,7 +88,17 @@
                                 <small>@cheep.FormattedTimeStamp</small>
                                 <br><br>
                                 <p>@cheep.Text</p>
-
+                                <div>
+                                    @* If image reference is not null then make an image element *@
+                                    @if (cheep.ImageReference != null)
+                                    {
+                                        // (R0lGODlh) Is what all base64 encoded GIFs start with
+                                        string mimeType = cheep.ImageReference.StartsWith("R0lGODlh") ? "image/gif" : "image/png";
+                                        <a href="data:@mimeType;base64,@cheep.ImageReference" style="cursor: pointer;">
+                                            <img src="data:@mimeType;base64,@cheep.ImageReference" alt="Cheep Image"/>
+                                        </a>
+                                    }
+                                </div>
                             </li>
                         }
                     </ul>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8b07ab12-8631-4025-ad48-b0c4943f44a0)
## Things added
Users can now also download the Images or GIFs that they might have uploaded to their cheeps. Before hand it was only the CSV file which would be downloaded. Now it is instead a .zip folder that gets downloaded, which contains the usual CSV file and also the images a user might have uploaded.

### Smaller details
Also added so that the pictures or GIFs are shown on the Personal Data page, since we also allow them to be downloaded now :D
![image](https://github.com/user-attachments/assets/e5ba31d0-3f50-4657-a593-036fbda68bb1)
