### PR TITLE
Bugfix for constraint bug in UserTimeline

### DIFF
--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -23,7 +23,7 @@
         <h2> @authorName's Timeline </h2>
     </div>
     <div class="Profile-Picture-Header">
-        @if (pageAuthor.ProfilePicture == null)
+        @if (pageAuthor?.ProfilePicture == null)
         {
             <img class="Profile-Picture" src="~/images/DefaultUser.png" alt="User profile image"/>
         }

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -148,8 +148,12 @@ public class UserTimelineModel : PageModel
     public async Task<IActionResult> OnPost()
     {
         string? currentAuthor = RouteData.Values["author"]?.ToString();
-        if (currentAuthor != null) CurrentAuthor = currentAuthor;
-
+        if (currentAuthor != null)
+        {
+            CurrentAuthor = currentAuthor;
+            PageAuthor = await _service.FindAuthorByName(currentAuthor);
+        }
+        
         UserAuthor = await _service.FindAuthorByName(User.Identity?.Name ?? string.Empty);
         
         PageNumber = pageNumber;
@@ -165,6 +169,10 @@ public class UserTimelineModel : PageModel
             } else {
                 Cheeps = await _service.GetCheepsFromAuthor(CurrentAuthor, PageNumber); 
             }
+            
+            FollowingList = await _service.GetFollowedAuthors(CurrentAuthor);
+            FollowingMeList = await _service.GetFollowingAuthors(CurrentAuthor);
+            
             return Page(); // Return the page with validation messages
         }
         


### PR DESCRIPTION
There was a bug in the UserTimeline when a user tried to send a cheep with no text. Instead of coming up with the error message, it would instead encounter a NullReferenceException. This was because the PageAuthor, FollowingList and FollowingMeList variables were not set in the OnPost method. Which was an issue when a constraint was met.

This meant that instead of simply just reloading the page, the program would stop because of the exception.
