### PR TITLE
Containerization of application

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -3,103 +3,37 @@ on:
   push:
     tags:
       - 'v*'  # This will trigger the workflow on any tag starting with 'v'
+  # allow manual triggers for testing purposes
+  workflow_dispatch:
+    manual: true
 
 jobs:
-  build_web:
+  build and push:
     runs-on: ubuntu-latest
-
+    
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v2
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+      - name: Publish app
+      - run: dotnet publish src/Chirp.Web/Chirp.Web.csproj -c Release
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
-          dotnet-version: 8.0.x
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Restore dependencies for Web
-        run: dotnet restore src/Chirp.Web/Chirp.Web.csproj
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build Web
-        run: dotnet build src/Chirp.Web/Chirp.Web.csproj --no-restore
-  
-  unit_test:
-    needs: build_web
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 8.0.x
-
-      - name: Restore dependencies for Unit Tests
-        run: dotnet restore test/Chirp.TestUnit/Chirp.TestUnit.csproj
-
-      - name: Run Unit Tests
-        env:
-          AUTHENTICATION_GITHUB_CLIENTID: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTID }}
-          AUTHENTICATION_GITHUB_CLIENTSECRET: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTSECRET }}
-        run: dotnet test test/Chirp.TestUnit/Chirp.TestUnit.csproj --verbosity normal
-  
-  integration_test:
-    needs: build_web
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 8.0.x
-
-      - name: Restore dependencies for Integration Tests
-        run: dotnet restore test/Chirp.TestIntegration/Chirp.TestIntegration.csproj
-
-      - name: Run Integration Tests
-        env:
-          AUTHENTICATION_GITHUB_CLIENTID: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTID }}
-          AUTHENTICATION_GITHUB_CLIENTSECRET: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTSECRET }}
-        run: dotnet test test/Chirp.TestIntegration/Chirp.TestIntegration.csproj --verbosity normal
-  
-  e2e_test:
-    needs: build_web
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 8.0.x
-
-      - name: Restore dependencies for End To End Tests
-        run: |
-          dotnet restore test/Chirp.TestE2E/Chirp.TestE2E.csproj
-
-      - name: Build End To End Tests
-        run: dotnet build test/Chirp.TestE2E/Chirp.TestE2E.csproj --no-restore
-
-      - name: Run Web Application
-        run: dotnet run --project src/Chirp.Web/Chirp.Web.csproj --urls "http://localhost:5273" &
-        env:
-          AUTHENTICATION_GITHUB_CLIENTID: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTID }}
-          AUTHENTICATION_GITHUB_CLIENTSECRET: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTSECRET }}
-
-      - name: Wait for Web Application to Start
-        run: sleep 10
-
-      - name: Install Playwright
-        run: pwsh test/Chirp.TestE2E/bin/Debug/net8.0/playwright.ps1 install
-
-      - name: End To End Test
-        env:
-          AUTHENTICATION_GITHUB_CLIENTID: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTID }}
-          AUTHENTICATION_GITHUB_CLIENTSECRET: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTSECRET }}
-          GITHUBTESTACCOUNTUSERNAME: ${{ secrets.GITHUBTESTACCOUNTUSERNAME }}
-          GITHUBTESTACCOUNTPASSWORD: ${{ secrets.GITHUBTESTACCOUNTPASSWORD }}
-        run: |
-          dotnet test test/Chirp.TestE2E/Chirp.TestE2E.csproj --filter "Category=End2End" --verbosity normal
+      - name: Build and push chirp
+        uses: docker/build-push-action@v6
+        with: 
+          context: .
+          file: ./Dockerfile.app
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/chirp:latest
 
   release:
     timeout-minutes: 60

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -3,20 +3,23 @@ on:
   push:
     tags:
       - 'v*'  # This will trigger the workflow on any tag starting with 'v'
-  # allow manual triggers for testing purposes
-  workflow_dispatch:
-    manual: true
+  workflow_dispatch: # allow manual triggers for testing purposes
 
 jobs:
-  build and push:
+  build_and_push:
     runs-on: ubuntu-latest
     
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+
       - name: Publish app
-      - run: dotnet publish src/Chirp.Web/Chirp.Web.csproj -c Release
+        run: dotnet publish src/Chirp.Web/Chirp.Web.csproj -c Release
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -65,41 +65,41 @@ jobs:
           AUTHENTICATION_GITHUB_CLIENTSECRET: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTSECRET }}
         run: dotnet test test/Chirp.TestIntegration/Chirp.TestIntegration.csproj --verbosity normal
         
-  e2e_test:
-    needs: build_web
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+  # e2e_test:
+  #   needs: build_web
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 8.0.x
+  #     - name: Setup .NET
+  #       uses: actions/setup-dotnet@v3
+  #       with:
+  #         dotnet-version: 8.0.x
 
-      - name: Restore dependencies for End To End Tests
-        run: |
-          dotnet restore test/Chirp.TestE2E/Chirp.TestE2E.csproj
+  #     - name: Restore dependencies for End To End Tests
+  #       run: |
+  #         dotnet restore test/Chirp.TestE2E/Chirp.TestE2E.csproj
 
-      - name: Build End To End Tests
-        run: dotnet build test/Chirp.TestE2E/Chirp.TestE2E.csproj --no-restore
+  #     - name: Build End To End Tests
+  #       run: dotnet build test/Chirp.TestE2E/Chirp.TestE2E.csproj --no-restore
 
-      - name: Run Web Application
-        run: dotnet run --project src/Chirp.Web/Chirp.Web.csproj --urls "http://localhost:5273" &
-        env:
-          AUTHENTICATION_GITHUB_CLIENTID: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTID }}
-          AUTHENTICATION_GITHUB_CLIENTSECRET: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTSECRET }}
+  #     - name: Run Web Application
+  #       run: dotnet run --project src/Chirp.Web/Chirp.Web.csproj --urls "http://localhost:5273" &
+  #       env:
+  #         AUTHENTICATION_GITHUB_CLIENTID: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTID }}
+  #         AUTHENTICATION_GITHUB_CLIENTSECRET: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTSECRET }}
 
-      - name: Wait for Web Application to Start
-        run: sleep 10
+  #     - name: Wait for Web Application to Start
+  #       run: sleep 10
 
-      - name: Install Playwright
-        run: pwsh test/Chirp.TestE2E/bin/Debug/net8.0/playwright.ps1 install
+  #     - name: Install Playwright
+  #       run: pwsh test/Chirp.TestE2E/bin/Debug/net8.0/playwright.ps1 install
 
-      - name: End To End Test
-        env:
-          AUTHENTICATION_GITHUB_CLIENTID: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTID }}
-          AUTHENTICATION_GITHUB_CLIENTSECRET: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTSECRET }}
-          GITHUBTESTACCOUNTUSERNAME: ${{ secrets.GITHUBTESTACCOUNTUSERNAME }}
-          GITHUBTESTACCOUNTPASSWORD: ${{ secrets.GITHUBTESTACCOUNTPASSWORD }}
-        run: |
-          dotnet test test/Chirp.TestE2E/Chirp.TestE2E.csproj --filter "Category=End2End" --verbosity normal
+  #     - name: End To End Test
+  #       env:
+  #         AUTHENTICATION_GITHUB_CLIENTID: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTID }}
+  #         AUTHENTICATION_GITHUB_CLIENTSECRET: ${{ secrets.AUTHENTICATION_GITHUB_CLIENTSECRET }}
+  #         GITHUBTESTACCOUNTUSERNAME: ${{ secrets.GITHUBTESTACCOUNTUSERNAME }}
+  #         GITHUBTESTACCOUNTPASSWORD: ${{ secrets.GITHUBTESTACCOUNTPASSWORD }}
+  #       run: |
+  #         dotnet test test/Chirp.TestE2E/Chirp.TestE2E.csproj --filter "Category=End2End" --verbosity normal

--- a/.gitignore
+++ b/.gitignore
@@ -432,7 +432,7 @@ test-results/
 
 # Mac bundle stuff
 *.dmg
-*.app
+# *.app
 
 # content below from: https://github.com/github/gitignore/blob/master/Global/macOS.gitignore
 # General

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -14,7 +14,7 @@ RUN mkdir -p /app/data
 EXPOSE 5273
 
 # Set environment variables
-ENV ASPNETCORE_URLS=http://+:5273
+ENV ASPNETCORE_URLS=http://0.0.0.0:5273
 ENV ConnectionStrings__DefaultConnection="Data Source=/app/data/chirp.db"
 
 # Run the application

--- a/Dockerfile.application
+++ b/Dockerfile.application
@@ -1,18 +1,21 @@
-# Use an official dotnet runtime as the base image
-FROM ubuntu/dotnet-runtime:8.0-24.04_beta
+# Use the ASP.NET runtime image (smaller than SDK)
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy
 
-# Set the working directory inside the container
+# Set the working directory
 WORKDIR /app
 
-# Copy application files
-COPY . .
+# Copy the published output
+COPY src/Chirp.Web/bin/Release/net8.0/publish . 
 
-# Expose the port the app will run on
-EXPOSE 5000
-
-# Ensures data persistency
+# Create data directory for SQLite database
 RUN mkdir -p /app/data
-ENV DB_PATH=/app/data
 
-# Run the Sinatra application when the container starts
-CMD ["dotnet", "run"]
+# Expose the port
+EXPOSE 5273
+
+# Set environment variables
+ENV ASPNETCORE_URLS=http://+:5273
+ENV ConnectionStrings__DefaultConnection="Data Source=/app/data/chirp.db"
+
+# Run the application
+ENTRYPOINT ["dotnet", "Chirp.Web.dll"]

--- a/Dockerfile.application
+++ b/Dockerfile.application
@@ -1,0 +1,18 @@
+# Use an official dotnet runtime as the base image
+FROM ubuntu/dotnet-runtime:8.0-24.04_beta
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy application files
+COPY . .
+
+# Expose the port the app will run on
+EXPOSE 5000
+
+# Ensures data persistency
+RUN mkdir -p /app/data
+ENV DB_PATH=/app/data
+
+# Run the Sinatra application when the container starts
+CMD ["dotnet", "run"]

--- a/Remote-files/docker-compose-app.yml
+++ b/Remote-files/docker-compose-app.yml
@@ -1,8 +1,6 @@
 services:
   chirp:
-    build:
-      context: .
-      dockerfile: Dockerfile.app
+    image: ${DOCKER_USERNAME}/chirp
     container_name: chirp
     environment:
       - ASPNETCORE_URLS=http://0.0.0.0:5273

--- a/Remote-files/pull_and_deploy.sh
+++ b/Remote-files/pull_and_deploy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd /chirp
+
+docker compose -f docker-compose-app.yml down
+docker compose -f docker-compose-app.yml pull
+docker compose -f docker-compose-app.yml up -d

--- a/Remote-files/sync_folder.sh
+++ b/Remote-files/sync_folder.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rsync r . $SSH_USER@$SSH_HOST:Chirp

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -1,0 +1,20 @@
+services:
+  chirp:
+    build:
+      context: .
+      dockerfile: Dockerfile.application
+    container_name: chirp
+    environment:
+      - ASPNETCORE_URLS=http://0.0.0.0:5273
+      - ConnectionStrings__DefaultConnection=Data Source=/app/data/chirp.db
+      - AUTHENTICATION_GITHUB_CLIENTID=${GITHUB_CLIENTID}
+      - AUTHENTICATION_GITHUB_CLIENTSECRET=${GITHUB_CLIENTSECRET}
+    volumes:
+      - chirp-data:/app/data
+    ports:
+      - "5273:5273"
+    restart: unless-stopped
+
+volumes:
+  chirp-data:
+    driver: local

--- a/src/Chirp.Web/Pages/Shared/_Layout.cshtml
+++ b/src/Chirp.Web/Pages/Shared/_Layout.cshtml
@@ -13,7 +13,7 @@
 </head>
 <body>
 <div class=page>
-    <h1><img src="/images/icon1.png" alt="Icon1"/>Chirp!</h1>
+    <h1><img src="/images/icon1.png" alt="icon1"/>Chirp!</h1>
 
     <aside class="navigation">
         <partial name="_Navbar"/>

--- a/src/Chirp.Web/Pages/Shared/_Navbar.cshtml
+++ b/src/Chirp.Web/Pages/Shared/_Navbar.cshtml
@@ -2,7 +2,7 @@
     @if (User.Identity != null && User.Identity.IsAuthenticated)
     {
         <div>
-            <a href="/@(User.Identity.Name)"> <img src="/images/Icon1.svg" alt="Home Symbol"/>My timeline</a> 
+            <a href="/@(User.Identity.Name)"> <img src="/images/icon1.svg" alt="Home Symbol"/>My timeline</a> 
             <a href="/"><img src="/images/Home.svg" alt="Home Symbol"/> Public timeline</a> 
             <a href="/identity/Account/Manage"> <img src="/images/User.svg" alt="Login Symbol"/>Manage account</a>  
             <a href="/Identity/Account/Logout"> <img src="/images/ArrowRightStartOnRectangle.svg" alt="Login Symbol"/>Logout</a> 

--- a/src/Chirp.Web/Pages/Shared/_mobileNavbar.cshtml
+++ b/src/Chirp.Web/Pages/Shared/_mobileNavbar.cshtml
@@ -1,7 +1,7 @@
 ﻿<div class=mobile-navigation>
     @if (User.Identity != null && User.Identity.IsAuthenticated)
     {
-        <a href="/@(User.Identity.Name)"> <img src="/images/Icon1.svg" alt="Home Symbol"/>@*My timeline*@</a> 
+        <a href="/@(User.Identity.Name)"> <img src="/images/icon1.svg" alt="Home Symbol"/>@*My timeline*@</a> 
         <a href="/"><img src="/images/Home.svg" alt="Home Symbol"/>@*Public timeline*@</a> 
         <a href="/identity/Account/Manage"> <img src="/images/User.svg" alt="Login Symbol"/>@*Manage account*@</a>  
         <a href="/Identity/Account/Logout"> <img src="/images/ArrowRightStartOnRectangle.svg" alt="Login Symbol"/>@*Logout*@</a> 


### PR DESCRIPTION
This pull request introduces significant changes to the deployment and build process for the Chirp application, focusing on Dockerization and workflow simplification. The main improvements include adding Docker support for building and running the app, providing deployment scripts and compose files, and streamlining the GitHub Actions workflows for building, testing, and publishing the application. Additionally, there are minor fixes to image references in the UI.

**Deployment and Dockerization:**

* Added a production-ready `Dockerfile.app` that uses the ASP.NET runtime image, sets up environment variables, exposes the application port, and configures persistent data storage for SQLite.
* Introduced `docker-compose-app.yml` and `Remote-files/docker-compose-app.yml` for orchestrating the Chirp service, including environment variables, volume mounts for data persistence, and port mapping. [[1]](diffhunk://#diff-0d71cf2466771cfcaaf3d2404a5f4f0448f9e0e5c9bd2308b5ce623bc5a276c3R1-R20) [[2]](diffhunk://#diff-ac795384c2ab48c7ee63f7b4b537d52238643a0a8add138edb2c3232480db460R1-R18)
* Added deployment helper scripts: `Remote-files/pull_and_deploy.sh` for pulling and restarting the Docker container, and `Remote-files/sync_folder.sh` for syncing files to a remote server. [[1]](diffhunk://#diff-0fc94845e060577c7a6214e7146f706e8ae43f8a1ab6b635fef9f1b6a7b5ab2fR1-R7) [[2]](diffhunk://#diff-c4d048871a5a1ea27750f54599d2942312c270343bf849c89890d3bbdab545f0R1-R3)

**CI/CD Workflow Changes:**

* Refactored `.github/workflows/Publish.yml` to combine build and Docker push steps into a single job, enable manual workflow dispatch, and remove separate unit, integration, and end-to-end test jobs from the publish pipeline.
* Commented out the end-to-end test job in `.github/workflows/build_and_test.yml`, effectively disabling E2E tests in CI for now.

**UI Fixes:**

* Fixed inconsistent image file naming in navigation components, changing references from `Icon1.svg` to `icon1.svg` for consistency and to prevent case-related issues. [[1]](diffhunk://#diff-eda8d695e46a48e28c661019877bcb234f2bf582a8a4a9d74dc1d5cbb6a41bf1L5-R5) [[2]](diffhunk://#diff-daf424d2510f62dcee39a272a04a60823c3db78456e60cfc3aba4c0c00b2c977L4-R4) [[3]](diffhunk://#diff-0062974f44579fda6af38b77916efe50e7934e717f938419f7f47eb496572b24L16-R16)